### PR TITLE
Add statistics of deaths in 2020

### DIFF
--- a/deaths_statistics.csv
+++ b/deaths_statistics.csv
@@ -1,0 +1,10 @@
+Zona,Provincias,2018,2019,2020,2020-01,2020-02,2020-03
+1,Esmeraldas;Imbabura;Carchi,1053,1107,952,373,359,220
+2,Napo;Orellana;Sucumbios;Pastaza,405,433,401,170,139,92
+3,Cotopaxi;Bolivar;Tungurahua;Chimborazo,2073,2002,1793,667,659,467
+4,Manabi;Santo Domingo de los Tsachilas,2130,2358,2022,827,732,463
+5,Santa Elena;Milagro;Los Rios;Galapagos,1281,1291,1081,417,402,262
+6,Canar;Azuay;Morona Santiago,1416,1365,1253,516,442,295
+7,El Oro;Loja;Zamora Chinchipe,1466,1487,1220,534,410,276
+8,Guayas,5132,5645,6804,1943,1679,3182
+9,Pichincha,3320,3308,3377,1202,1140,1035


### PR DESCRIPTION
Source: Dirección General de Registro Civil, via Maria Paula Romo, via Twitter (https://twitter.com/mariapaularomo/status/1246190700720513027)

Data include all deaths registered by April 1, 2020, during the 3 months of January, February and March 2020, and the same first 3 months of 2018 and 2019.
Zones correspond to regional zones defined by Registro Civil and most of them include multiple provinces, except for Zone 8 (Guayas) and 9 (Pichincha).